### PR TITLE
Fix: Remove /logout route from BackendAuthGuard

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -43,13 +43,14 @@ Route::prefix('/admin')->group(function () {
     Route::get('/register', 'Auth\RegisterController@index')->name('signup');
 
     Route::post('/register', 'Auth\RegisterController@register')->name('register');
+    Route::get('/logout', 'Auth\LogoutController@index')->name('logout');
+
 });
 
 // Protected Routes
 Route::group(['prefix' => '/admin', 'middleware' => 'backend.auth'], function () {
     Route::get('/activate', 'ActivateController@index')->name('activate.user');
 
-    Route::get('/logout', 'Auth\LogoutController@index')->name('logout');
     // dashboard
     Route::get('/dashboard', function () {
         return view('backend.dashboard');


### PR DESCRIPTION
# Description

When an unauthenticated user tries to access the protected routes., it redirects the user to the logout route. but this route was protected by the BackendAuth Guard, this caused a too many redirect error on the browser. I removed the /logout route from the BackendAuthGuard

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnin